### PR TITLE
Allow size of 0 as acceptable byte size

### DIFF
--- a/Sources/AvroDecoder.swift
+++ b/Sources/AvroDecoder.swift
@@ -115,7 +115,7 @@ open class AvroDecoder {
     open func decodeBytes() -> [UInt8]? {
         if let sizeLong = decodeLong() {
             let size = Int(sizeLong)
-            if size <= Int(bytes.count) && size != 0 {
+            if size <= Int(bytes.count) && size >= 0 {
                 let tmp = bytes[0..<size]
                 bytes.removeSubrange(0..<size)
                 return [UInt8](tmp)


### PR DESCRIPTION
- In the case of an empty string, we should allow size of 0.